### PR TITLE
Получение информации о текущем курсе обмена / rateType параметр

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -196,6 +196,7 @@ export interface IGetExchangeInfoRequest {
 	from: string
 	to: string
 	livetime?: number
+	rateType?: 'exchange' | 'invoice' | 'checkout'
 }
 
 export interface IGetExchangeInfoResponse extends IResponse {


### PR DESCRIPTION
https://cp.gmpays.com/apidoc#anchor7

rateType[STRING] — Параметр необязательный. `exchange` - курс при обменах, ставится по умолчанию, если параметр не передан; `invoice` - курс при пополнениях; `checkout` - курс при выплатах

